### PR TITLE
Fix five assorted gameplay bugs

### DIFF
--- a/modules/powers.js
+++ b/modules/powers.js
@@ -37,9 +37,9 @@ export const powers={
       }, duration);
     }
   },
-  heal:{emoji:"❤️",desc:"+30 HP",apply:()=>{
+  heal:{emoji:"❤️",desc:"+30 HP",apply:(utils, game)=>{
       state.player.health=Math.min(state.player.maxHealth,state.player.health+30);
-      window.gameHelpers.play('pickupSound');
+      game.play('pickupSound');
   }},
   shockwave:{emoji:"💥",desc:"Expanding wave damages enemies.",apply:(utils, game, mx, my, options = {})=>{
       const { damageModifier = 1.0, origin = state.player } = options;
@@ -134,20 +134,21 @@ export const powers={
     emoji:"🌀",
     desc:"Pulls enemies for 1s",
     apply:(utils, game)=>{
-        game.play('gravitySound'); 
-        state.gravityActive=true; 
-        state.gravityEnd=Date.now()+1000; 
-        utils.spawnParticles(state.particles, innerWidth/2, innerHeight/2,"#9b59b6",100,4,40,5); 
-        
+        game.play('gravitySound');
+        state.gravityActive=true;
+        state.gravityEnd=Date.now()+1000;
+        const { x, y } = state.player;
+        utils.spawnParticles(state.particles, x, y,"#9b59b6",100,4,40,5);
+
         if (state.player.purchasedTalents.has('temporal-collapse')) {
             setTimeout(() => {
                 if(state.gameOver) return;
-                state.effects.push({ 
-                    type: 'slow_zone', 
-                    x: innerWidth / 2, 
-                    y: innerHeight / 2, 
-                    r: 250, 
-                    endTime: Date.now() + 4000 
+                state.effects.push({
+                    type: 'slow_zone',
+                    x,
+                    y,
+                    r: 250,
+                    endTime: Date.now() + 4000
                 });
             }, 1000);
         }

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -48,8 +48,8 @@ function updatePantheonUI() {
         const coreData = bossData.find(b => b.id === buff.coreId);
         if (!coreData) return;
 
-        const remaining = (buff.endTime - now) / 1000;
-        
+        const remaining = Math.max(0, (buff.endTime - now) / 1000);
+
         const iconEl = document.createElement('div');
         iconEl.className = 'pantheon-buff-icon';
         iconEl.setAttribute('data-tooltip-text', `${coreData.name} (${remaining.toFixed(1)}s)`);
@@ -77,7 +77,7 @@ function updateStatusEffectsUI() {
     state.player.statusEffects.forEach(effect => {
         const remaining = effect.endTime - now;
         const duration = effect.endTime - effect.startTime;
-        const progress = Math.max(0, remaining) / duration;
+        const progress = duration > 0 ? Math.max(0, remaining) / duration : 0;
         const iconEl = document.createElement('div');
         iconEl.className = 'status-icon';
         iconEl.setAttribute('data-tooltip-text', `${effect.name} (${(remaining / 1000).toFixed(1)}s)`);
@@ -165,7 +165,7 @@ function updateAberrationCoreUI() {
         }
     } else {
         aberrationCoreSocket.classList.remove('active');
-        aberrationCoreSocket.style.setProperty('--nexus-glow', 'var(--nexus-glow)'); // Reset to default CSS variable
+        aberrationCoreSocket.style.removeProperty('--nexus-glow'); // Reset to default CSS variable
         aberrationCoreIcon.style.backgroundColor = 'transparent';
         if (aberrationCoreIcon.firstChild?.id !== 'aberration-core-cooldown') {
             aberrationCoreIcon.innerHTML = `<div id="aberration-core-cooldown" class="cooldown-overlay"></div>◎`;


### PR DESCRIPTION
## Summary
- Fix heal power using global helpers instead of provided game instance
- Spawn gravity power effects at player location and reuse captured coordinates
- Clamp Pantheon buff timers and handle zero-duration status effects
- Clear aberration core glow on unequip

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a33eaa9c588331b1a1bc6e0cd1a5fd