### PR TITLE
Fix miscellaneous logic bugs in utility and game management code

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 // modules/main.js
 import { state, resetGame, loadPlayerState, savePlayerState } from './modules/state.js';
+import { LEVELING_CONFIG } from './modules/config.js';
 import { bossData } from './modules/bosses.js';
 import { AudioManager } from './modules/audio.js';
 import { updateUI, populateLevelSelect, showCustomConfirm, populateOrreryMenu, populateAberrationCoreMenu, showUnlockNotification } from './modules/ui.js';
@@ -35,11 +36,9 @@ window.setLevel = function(level) {
     }
     state.player.level = level;
     state.player.essence = 0;
-    let nextLevelXP = 100;
-    for (let i = 1; i < level; i++) {
-        nextLevelXP = Math.floor(nextLevelXP * 1.12);
-    }
-    state.player.essenceToNextLevel = nextLevelXP;
+    // Use the same linear formula as the main game to avoid mismatched XP requirements.
+    state.player.essenceToNextLevel =
+        LEVELING_CONFIG.BASE_XP + (level - 1) * LEVELING_CONFIG.ADDITIONAL_XP_PER_LEVEL;
     savePlayerState();
     updateUI();
     console.log(`Player level set to ${level}.`);

--- a/modules/ascension.js
+++ b/modules/ascension.js
@@ -33,11 +33,12 @@ function isTalentVisible(talent) {
         return false;
     }
 
-    if (talent.prerequisites.length === 0) {
+    const prerequisites = talent.prerequisites || [];
+    if (prerequisites.length === 0) {
         return true;
     }
 
-    return talent.prerequisites.every(prereqId => {
+    return prerequisites.every(prereqId => {
         const prereqTalent = allTalents[prereqId];
         if (!prereqTalent) return false;
 

--- a/modules/state.js
+++ b/modules/state.js
@@ -211,6 +211,7 @@ export function resetGame(isArena = false) {
   state.player.activePantheonBuffs = [];
   state.player.shield = false;
   state.player.berserkUntil = 0;
+  state.player.talent_states.phaseMomentum.active = false;
   state.player.talent_states.phaseMomentum.lastDamageTime = Date.now();
   state.player.talent_states.reactivePlating.cooldownUntil = 0;
   state.player.infected = false;

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -161,6 +161,8 @@ export function drawLightning(ctx, x1, y1, x2, y2, color, width = 2) {
 }
 
 export function randomInRange(min, max) {
+  // Guard against callers accidentally passing arguments in the wrong order.
+  if (min > max) [min, max] = [max, min];
   return Math.random() * (max - min) + min;
 }
 
@@ -173,7 +175,8 @@ export function lineCircleCollision(x1, y1, x2, y2, cx, cy, r) {
   const onSegment = () => {
     const d1 = Math.hypot(closestX - x1, closestY - y1);
     const d2 = Math.hypot(closestX - x2, closestY - y2);
-    return d1 + d2 >= len - 0.1 && d1 + d2 <= len + 0.1;
+    // Compare using an absolute tolerance to avoid floating point drift.
+    return Math.abs(d1 + d2 - len) <= 0.1;
   };
   if (!onSegment()) {
     const dist1 = Math.hypot(cx - x1, cy - y1);


### PR DESCRIPTION
## Summary
- handle reversed arguments and floating point tolerance in utility helpers
- guard against missing talent prerequisites and reset phase momentum state on game reset
- align debug `setLevel` command with leveling config

## Testing
- `node --check modules/utils.js`
- `node --check modules/ascension.js`
- `node --check modules/state.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a35747353c8331a7e0a13a5ba5e519